### PR TITLE
include slides/*.jade

### DIFF
--- a/gulp/tasks/jade.js
+++ b/gulp/tasks/jade.js
@@ -5,12 +5,14 @@ var gulp     = require('gulp')
     ,plumber = require('gulp-plumber')
     ,paths   = require('../paths')
     ,fs      = require('fs')
+    ,glob    = require('gulp-jade-globbing')
     ,jade    = require('gulp-jade');
 
 // Call Jade to compile Templates
 module.exports = gulp.task('jade', function () {
   return gulp.src(paths.source.files.jade)
     .pipe(plumber())
+    .pipe(glob())
     .pipe(jade({
       pretty: true
     }))

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-gh-pages": "^0.5.2",
     "gulp-imagemin": "^2.2.1",
     "gulp-jade": "^1.0.0",
+    "gulp-jade-globbing": "^0.1.9",
     "gulp-plumber": "^1.0.0",
     "gulp-stylus": "^2.0.1",
     "gulp-uglify": "^1.1.0",

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -4,6 +4,5 @@ html
 	body
 		.reveal
 			.slides
-				include ../slides/slide-1
-				include ../slides/slide-2
+				include ../slides/*.jade
 		include inc/scripts


### PR DESCRIPTION
Now you no longer need to ``include`` for each file in ``index.jade``

**Organizing**
To organize the sequence of slides you need to naming them with numbers:
```
0_slide.jade
1_slide.jade
2_intro.jade
3_example.jade
```